### PR TITLE
Add CI workflow to check for commonly misspelled words

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,9 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/spell-check/.codespellrc
+# See: https://github.com/codespell-project/codespell#using-a-config-file
+[codespell]
+# In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
+ignore-words-list = ,
+skip = ./.git,./.licenses,__pycache__,node_modules,./go.mod,./go.sum,./package-lock.json,./poetry.lock,./yarn.lock
+builtin = clear,informal,en-GB_to_en-US
+check-filenames =
+check-hidden =

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,0 +1,26 @@
+# Source: https://github.com/per1234/.github/blob/main/workflow-templates/spell-check.md
+name: Spell Check
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+  pull_request:
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch new misspelling detections resulting from dictionary updates.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  spellcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Spell check
+        uses: codespell-project/actions-codespell@master

--- a/README.md
+++ b/README.md
@@ -46,6 +46,6 @@ ros2 topic echo /l3xz/cmd_vel_robot
 #### Parameters
 | Name | Default | Description |
 |:-:|:-:|-|
-| `joy_dev_node` | `/dev/input/js0` | Name of input device node under which joystick is registed in Linux. |
-| `topic_robot_stick` | `cmd_vel_robot` | Name of topic for controlling L3X-Z foward/sideways/angular speed (linear.x/y, angular.z). |
+| `joy_dev_node` | `/dev/input/js0` | Name of input device node under which joystick is registered in Linux. |
+| `topic_robot_stick` | `cmd_vel_robot` | Name of topic for controlling L3X-Z forward/sideways/angular speed (linear.x/y, angular.z). |
 | `topic_robot_pad` | `cmd_vel_head` | Name of topic for controlling L3X-Z sensor head. |

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 :floppy_disk: `l3xz_teleop`
 ===========================
 [![Build Status](https://github.com/107-systems/l3xz_teleop/actions/workflows/ros2.yml/badge.svg)](https://github.com/107-systems/l3xz_teleop/actions/workflows/ros2.yml)
+[![Spell Check status](https://github.com/107-systems/l3xz_teleop/actions/workflows/spell-check.yml/badge.svg)](https://github.com/107-systems/l3xz_teleop/actions/workflows/spell-check.yml)
 
 Teleoperation for L3X-Z via PS3 joystick and ROS topics.
 


### PR DESCRIPTION
On every push, pull request, and periodically, use the codespell-project/actions-codespell action to check for commonly
misspelled words.

In the event of a false positive, the problematic word should be added, in all lowercase, to the ignore-words-list field
of ./.codespellrc. Regardless of the case of the word in the false positive, it must be in all lowercase in the ignore
list. The ignore list is comma-separated with no spaces.