### PR TITLE
Implement full node state within state-machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,18 +78,20 @@ ros2 topic echo /l3xz/cmd_vel_robot
 | `/l3xz/cmd_robot/req_down` |       [`std_msgs/Bool`](http://docs.ros.org/en/api/std_msgs/html/msg/Bool.html)       |
 
 ##### Parameters
-|                   Name                   |       Default        | Description                                                                                                 |
-|:----------------------------------------:|:--------------------:|-------------------------------------------------------------------------------------------------------------|
-|               `joy_topic`                |        `joy`         | Name of topic from where we are subscribing joystick messages.                                              |
-|         `joy_topic_deadline_ms`          |         100          | Deadline in milliseconds within which a new joystick message is expected.                                   |
-|  `joy_topic_liveliness_lease_duration`   |         1000         | The time within which the RMW node or publisher must show that it is alive.                                 | 
-|              `robot_topic`               |   `cmd_vel_robot`    | Name of topic for controlling L3X-Z forward/angular speed (`linear.x`/, `angular.z`).                       |
-|     `robot_topic_publish_period_ms`      |         100          | Publishing period for robot messages in milliseconds (ms).                                                  |
-|               `head_topic`               |    `cmd_vel_head`    | Name of topic for controlling L3X-Z sensor head (`angular.y`/, `angular.z`) in degree per second (**dps**). |
-|      `head_topic_publish_period_ms`      |          50          | Publishing period for head messages in milliseconds (ms).                                                   |
-|           `robot_req_up_topic`           |  `cmd_robot/req_up`  | Name of topic for requesting L3X-Z to stand up.                                                             |
-|  `robot_req_up_topic_publish_period_ms`  |         250          | Publishing period for stand up request messages in milliseconds (ms).                                       |
-|          `robot_req_down_topic`          | `cmd_robot/req_down` | Name of topic for requesting L3X-Z to sit down.                                                             |
-| `robot_req_down_topic_publish_period_ms` |         250          | Publishing period for sit down request messages in milliseconds (ms).                                       |
-|              `pan_max_dps`               |        10.0°         | Maximum target angular velocity for pan servo of the L3X-Z sensor head.                                     |
-|              `tilt_max_dps`              |        10.0°         | Maximum target angular velocity for tilt servo of the L3X-Z sensor head.                                    |
+|                   Name                   |       Default        | Description                                                                                                  |
+|:----------------------------------------:|:--------------------:|--------------------------------------------------------------------------------------------------------------|
+|               `joy_topic`                |        `joy`         | Name of topic from where we are subscribing joystick messages.                                               |
+|         `joy_topic_deadline_ms`          |         100          | Deadline in milliseconds within which a new joystick message is expected.                                    |
+|  `joy_topic_liveliness_lease_duration`   |         1000         | The time within which the RMW node or publisher must show that it is alive.                                  | 
+|              `robot_topic`               |   `cmd_vel_robot`    | Name of topic for controlling L3X-Z forward/angular speed (`linear.x`/, `angular.z`).                        |
+|     `robot_topic_publish_period_ms`      |         100          | Publishing period for robot messages in milliseconds (ms).                                                   |
+|               `head_topic`               |    `cmd_vel_head`    | Name of topic for controlling L3X-Z sensor head (`angular.y`/, `angular.z`) in degree per second (**dps**).  |
+|      `head_topic_publish_period_ms`      |          50          | Publishing period for head messages in milliseconds (ms).                                                    |
+|         `head_topic_deadline_ms`         |         100          | Deadline in milliseconds within which a new head message should be published.                                |
+| `head_topic_liveliness_lease_duration`   |         1000         | The time within which the RMW node or publisher must show that it is alive.                                  |
+|           `robot_req_up_topic`           |  `cmd_robot/req_up`  | Name of topic for requesting L3X-Z to stand up.                                                              |
+|  `robot_req_up_topic_publish_period_ms`  |         250          | Publishing period for stand up request messages in milliseconds (ms).                                        |
+|          `robot_req_down_topic`          | `cmd_robot/req_down` | Name of topic for requesting L3X-Z to sit down.                                                              |
+| `robot_req_down_topic_publish_period_ms` |         250          | Publishing period for sit down request messages in milliseconds (ms).                                        |
+|              `pan_max_dps`               |        10.0°         | Maximum target angular velocity for pan servo of the L3X-Z sensor head.                                      |
+|              `tilt_max_dps`              |        10.0°         | Maximum target angular velocity for tilt servo of the L3X-Z sensor head.                                     |

--- a/include/l3xz_teleop/Node.h
+++ b/include/l3xz_teleop/Node.h
@@ -79,6 +79,7 @@ private:
 
   struct liveliness_gained { };
   struct liveliness_lost { };
+  struct head_pub_timer_fired { };
 
   struct FsmImpl {
     auto operator()() const noexcept {
@@ -100,6 +101,9 @@ private:
             node._req_up_msg   = Node::create_init_req_up_msg();
             node._req_down_msg = Node::create_init_req_down_msg();
           }  = "standby"_s
+          , "active"_s + event<head_pub_timer_fired> /
+            [](Node & node) { node._head_pub->publish(node._head_msg); }
+            = "active"_s
       );
     }
   };

--- a/include/l3xz_teleop/Node.h
+++ b/include/l3xz_teleop/Node.h
@@ -96,11 +96,6 @@ private:
           [](Node & node)
           {
             RCLCPP_WARN(node.get_logger(), "liveliness lost for \"%s\"", node._joy_sub->get_topic_name());
-            /* Set all teleop messages to be at their initial value. */
-            node._robot_msg    = Node::create_init_robot_msg();
-            node._head_msg     = Node::create_init_head_msg();
-            node._req_up_msg   = Node::create_init_req_up_msg();
-            node._req_down_msg = Node::create_init_req_down_msg();
           }
           = "standby"_s
         , "active"_s + event<robot_pub_timer_fired> /

--- a/include/l3xz_teleop/Node.h
+++ b/include/l3xz_teleop/Node.h
@@ -77,8 +77,8 @@ private:
 
   void init_pub();
 
-  struct liveliness_gained { };
-  struct liveliness_lost { };
+  struct joy_sub_liveliness_gained { };
+  struct joy_sub_liveliness_lost { };
   struct robot_pub_timer_fired { };
   struct head_pub_timer_fired { };
 
@@ -86,13 +86,13 @@ private:
     auto operator()() const noexcept {
       using namespace boost::sml;
       return make_transition_table(
-        *"standby"_s + event<liveliness_gained> /
+        *"standby"_s + event<joy_sub_liveliness_gained> /
           [](Node & node)
           {
             RCLCPP_INFO(node.get_logger(), "liveliness gained for \"%s\"", node._joy_sub->get_topic_name());
           }
           = "active"_s
-        ,"active"_s + event<liveliness_lost> /
+        ,"active"_s + event<joy_sub_liveliness_lost> /
           [](Node & node)
           {
             RCLCPP_WARN(node.get_logger(), "liveliness lost for \"%s\"", node._joy_sub->get_topic_name());

--- a/include/l3xz_teleop/Node.h
+++ b/include/l3xz_teleop/Node.h
@@ -101,13 +101,20 @@ private:
             node._head_msg     = Node::create_init_head_msg();
             node._req_up_msg   = Node::create_init_req_up_msg();
             node._req_down_msg = Node::create_init_req_down_msg();
-          }  = "standby"_s
-          , "active"_s + event<robot_pub_timer_fired> /
-            [](Node & node) { node._robot_pub->publish(node._robot_msg); }
-            = "active"_s
-          , "active"_s + event<head_pub_timer_fired> /
-            [](Node & node) { node._head_pub->publish(node._head_msg); }
-            = "active"_s
+          }
+          = "standby"_s
+        , "active"_s + event<robot_pub_timer_fired> /
+          [](Node & node)
+          {
+            node._robot_pub->publish(node._robot_msg);
+          }
+          = "active"_s
+        , "active"_s + event<head_pub_timer_fired> /
+          [](Node & node)
+          {
+            node._head_pub->publish(node._head_msg);
+          }
+          = "active"_s
       );
     }
   };

--- a/include/l3xz_teleop/Node.h
+++ b/include/l3xz_teleop/Node.h
@@ -79,6 +79,7 @@ private:
 
   struct liveliness_gained { };
   struct liveliness_lost { };
+  struct robot_pub_timer_fired { };
   struct head_pub_timer_fired { };
 
   struct FsmImpl {
@@ -101,6 +102,9 @@ private:
             node._req_up_msg   = Node::create_init_req_up_msg();
             node._req_down_msg = Node::create_init_req_down_msg();
           }  = "standby"_s
+          , "active"_s + event<robot_pub_timer_fired> /
+            [](Node & node) { node._robot_pub->publish(node._robot_msg); }
+            = "active"_s
           , "active"_s + event<head_pub_timer_fired> /
             [](Node & node) { node._head_pub->publish(node._head_msg); }
             = "active"_s

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -117,9 +117,9 @@ void Node::init_sub()
     [this, joy_topic](rclcpp::QOSLivelinessChangedInfo & event) -> void
     {
       if (event.alive_count > 0)
-        _sm->process_event(liveliness_gained{});
+        _sm->process_event(joy_sub_liveliness_gained{});
       else
-        _sm->process_event(liveliness_lost{});
+        _sm->process_event(joy_sub_liveliness_lost{});
     };
 
   _joy_sub = create_subscription<sensor_msgs::msg::Joy>(

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -216,7 +216,7 @@ void Node::init_head_pub()
     head_topic_publish_period,
     [this]()
     {
-      _head_pub->publish(_head_msg);
+      _sm->process_event(head_pub_timer_fired{});
     });
 }
 

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -193,7 +193,7 @@ void Node::init_robot_pub()
     std::chrono::milliseconds(get_parameter("robot_topic_publish_period_ms").as_int()),
     [this]()
     {
-      _robot_pub->publish(_robot_msg);
+      _sm->process_event(robot_pub_timer_fired{});
     });
 }
 

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -114,7 +114,7 @@ void Node::init_sub()
     };
 
   _joy_sub_options.event_callbacks.liveliness_callback =
-    [this, joy_topic](rclcpp::QOSLivelinessChangedInfo & event) -> void
+    [this](rclcpp::QOSLivelinessChangedInfo & event) -> void
     {
       if (event.alive_count > 0)
         _sm->process_event(joy_sub_liveliness_gained{});


### PR DESCRIPTION
Only transmit robot and head teleop messages when we are in active state. A lack of those messages being sent needs to be handled by the subscribing nodes.